### PR TITLE
REQ6-Instalando Express.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/ccalvarez/EmventsInc/issues"
   },
-  "homepage": "https://github.com/ccalvarez/EmventsInc"
+  "homepage": "https://github.com/ccalvarez/EmventsInc",
+  "dependencies": {
+    "express": "4.15.2"
+  }
 }


### PR DESCRIPTION
Usamos npm install para instalar Express.js.